### PR TITLE
Print appropriate error messages when two vertices are identical

### DIFF
--- a/src/common/util.py
+++ b/src/common/util.py
@@ -252,6 +252,10 @@ def counterclockwise_angle_between_vectors(h, i, j):
            θ <--- angle
            i
     """
+    # No two points may be the same. If they are, it's likely from noisy data and we should error.
+    if (h == i) or (h == j) or (i == j):
+        raise Exception(f"counterclockwise_angle_between_vectors: no points may be identical {h} {i} {j}")
+    
     # shift the vectors to be based at i
     v1 = (h[0] - i[0], h[1] - i[1])
     v2 = (j[0] - i[0], j[1] - i[1])

--- a/src/common/vector.py
+++ b/src/common/vector.py
@@ -158,7 +158,7 @@ class Vector(object):
             self.extract_four_sides()
         except Exception as e:
             self.render()
-            print(f"Error while processing {self.id}:")
+            print(f"Error while processing id {self.id} in file {self.filename}:")
             raise e
 
         if render:

--- a/src/run_one_by_one.py
+++ b/src/run_one_by_one.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Example of running by invoking with one photo at a time
 """

--- a/src/solve.py
+++ b/src/solve.py
@@ -58,13 +58,13 @@ def _build_board(connectivity, output_path, metadata_path):
     dest_incenters = [(555, 444)] * 1000
     dest_rotations = [0.123] * 1000
     for i in range(1, 1001):
-        dest_incenters[i] = 0.123
-        dest_rotations[i] = 0.123
         for j in range(4):
-            path = os.path.join(metadata_path, f'side_{i}_{j}.json')
-            with open(path, 'rw') as f:
+            metadata_input_path = os.path.join(metadata_path, f'side_{i}_{j}.json')
+            solution_output_path = os.path.join(output_path, f'side_{i}_{j}.json')
+            with open(metadata_input_path, 'r') as f:
                 metadata = json.load(f)
-                metadata['dest_photo_space_incenter'] = dest_incenters[i]
-                metadata['dest_rotation'] = dest_rotations[i]
+                metadata['dest_photo_space_incenter'] = dest_incenters[i-1]
+                metadata['dest_rotation'] = dest_rotations[i-1]
+            with open(solution_output_path, 'w') as f:
                 json.dump(metadata, f)
 


### PR DESCRIPTION
In the event that image noise causes two vertices to be identical, make sure an appropriate error is printed along with the filename of the image.