### PR TITLE
Show usage info of argc is not exactly 4

### DIFF
--- a/src/c/find_islands.c
+++ b/src/c/find_islands.c
@@ -385,7 +385,7 @@ void* worker(void* arg) {
 }
 
 int main(int argc, char *argv[]) {
-    if (argc < 3) {
+    if (argc != 4) {
         fprintf(stderr, "Usage: %s <input_directory> <output_directory> <min_island_area>\n", argv[0]);
         return 1;
     }


### PR DESCRIPTION
`argc` needs to be at least 4 (command <input_directory> <output_directory> <min_island_area>). Passing more arguments likely indicates an user error, print error message in that case